### PR TITLE
Update Percona Mongodb operator version

### DIFF
--- a/samples/sbo/restapi-mongodb-odo/mongo-cluster.yaml
+++ b/samples/sbo/restapi-mongodb-odo/mongo-cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: psmdb.percona.com/v1-11-0
+apiVersion: psmdb.percona.com/v1
 kind: PerconaServerMongoDB
 metadata:
   name: mongodb-instance

--- a/samples/sbo/restapi-mongodb-odo/operators/mongodb-percona-distribution.yaml
+++ b/samples/sbo/restapi-mongodb-odo/operators/mongodb-percona-distribution.yaml
@@ -7,7 +7,7 @@ spec:
   name: percona-server-mongodb-operator
   source: community-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: percona-server-mongodb-operator.v1.11.0
+  startingCSV: percona-server-mongodb-operator.v1
 ---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup


### PR DESCRIPTION
In OpenShift 4.10 and 4.11 the following error is returned.
```
  Conditions:
    Last Transition Time:  2022-10-21T16:41:54Z
    Message:               all available catalogsources are healthy
    Reason:                AllCatalogSourcesHealthy
    Status:                False
    Type:                  CatalogSourcesUnhealthy
    Message:               constraints not satisfiable: no operators found with name percona-server-mongodb-operator.v1.11.0 in channel  of package percona-server-mongodb-operator in the catalog referenced by subscription percona-server-mongodb-operator, subscription percona-server-mongodb-operator exists
    Reason:                ConstraintsNotSatisfiable
    Status:                True
    Type:                  ResolutionFailed
  Last Updated:            2022-10-21T16:41:57Z
Events:                    <none>
```
From the percona operator [v1.13 release notes](https://docs.percona.com/percona-operator-for-mongodb/RN/Kubernetes-Operator-for-PSMONGODB-RN1.13.0.html), it seems the 1.11 is no more supported.

> K8SPSMDB-715 Starting from now, the Opearator changed its API version to v1 instead of having a separate API version for each release. Three last API version are supported in addition to v1, which substantially reduces the size of Custom Resource Definition to prevent reaching the etcd limit

Signed-off-by: Francesco Ilario <filario@redhat.com>